### PR TITLE
Update init for overlay image support

### DIFF
--- a/init
+++ b/init
@@ -180,11 +180,11 @@ fi
 
 
 ##### MOUNTING #####
-if [[ "$ENABLE_OVERLAY_IMAGE" == "true" ]]; then
-	echo "ENABLE_OVERLAY_IMAGE value is true"
-	mount_overlay_rootfs
+if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
+	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
+	mount_overlay_rootfs || { echo "Failed to mount rootfs as overlay, falling back to wz_mini mounting" ; mount_wz_mini ; }
 else
-	echo "ENABLE_OVERLAY_IMAGE value is false"
+	echo "ENABLE_OVERLAY_FOR_ROOTFS value is false"
 	mount_wz_mini
 fi
 

--- a/init
+++ b/init
@@ -88,31 +88,41 @@ boot_stock() {
 }
 
 boot_wz_mini() {
-if ! [ -f $WZMINI_INIT_FILE ]; then
-	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
-	boot_stock
-else
-	mount --move /stock_rootfs /newroot
-	mount --move /sdcard /newroot/opt
 	move_virtual_filesystems
 	echo "Switching root to /newroot with wz_mini init"
 	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
-fi
 }
 
-boot_wz_mini_overlay() {
-if ! grep -q "overlayfs" /proc/filesystems; then
-	echo "overlayfs support is missing from this kernel, falling back to wz_mini"
-	boot_wz_mini
-else
+mount_wz_mini() {
+	mount --move /stock_rootfs /newroot
+	mount --move /sdcard /newroot/opt
+}
+
+mount_overlay_rootfs() { # Mount rootfs as overlay
+	if ! grep -q "overlayfs" /proc/filesystems; then
+		echo "overlayfs support is missing from this kernel"
+		return 1
+	fi
+
+	if ! [ -f $WZMINI_OVERLAY_FILE ]; then
+		echo "$WZMINI_OVERLAY_FILE is missing"
+		# Create overlay image from compressed empty overlay image file
+		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
+		echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
+			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
+		else
+			{ echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing" ; return 1 ; }
+		fi
+	fi
+
 	echo "Mounting rootfs as overlay"
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/jbd2/jbd2.ko
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
 	mkdir /overlay
-	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE, falling back to wz_mini without overlay image" ; boot_wz_mini ; }
+	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE" ; return 1 ; }
 
 	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/overlay /newroot
 
@@ -130,33 +140,22 @@ else
 	mkdir -p /newroot/overlay_mnt/stock_rootfs
 	mount --move /stock_rootfs /newroot/overlay_mnt/stock_rootfs
 	mount --move /overlay /newroot/overlay
+}
 
-	if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then
-		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is true"
-		echo "Mounting /system as overlay"
-		mkdir -p /newroot/overlay_mnt/stock_system
-		mkdir -p /newroot/overlay_mnt/system_overlay
-		mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
-		mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay /newroot/system
-	else
-		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is false"
-	fi
-
-	move_virtual_filesystems
-
-	echo "Switching root to /newroot with wz_mini init on overlay rootfs"
-	cp /tmp/wz_mini_initramfs.log /newroot/sdcard/wz_mini_initramfs.log
-	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
-fi
+mount_overlay_system() { # Mount /system as overlay
+	echo "Mounting /system as overlay"
+	mkdir -p /newroot/overlay_mnt/stock_system
+	mkdir -p /newroot/overlay_mnt/system_overlay
+	mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
+	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay /newroot/system
 }
 
 
-# Boot with stock firmware if wz_mini.conf is missing
+##### ERROR CHECKING AND DEBUGGING #####
 if ! [ -f $WZMINI_CONFIG_FILE ]; then
 	echo "$WZMINI_CONFIG_FILE is missing, falling back to stock firmware"
 	boot_stock
 else
-	echo "$WZMINI_CONFIG_FILE is found"
 	source $WZMINI_CONFIG_FILE
 
 	if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
@@ -175,25 +174,29 @@ else
 	fi
 fi
 
-# Boot with overlay image if the option is used
+if ! [ -f $WZMINI_INIT_FILE ]; then
+	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
+	boot_stock
+fi
+
+##### MOUNTING #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
-	if [ -f $WZMINI_OVERLAY_FILE ]; then
-		echo "$WZMINI_OVERLAY_FILE is found"
-		boot_wz_mini_overlay
-	else
-		echo "$WZMINI_OVERLAY_FILE is missing"
-		# Create overlay image from compressed empty overlay image 
-		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
-			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
-			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to extract $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE, falling back to wz_mini without overlay image" ; boot_wz_mini ; }
-			boot_wz_mini_overlay
+	if mount_overlay_rootfs; then
+		if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then # Mount /system as overlay if only mounting rootfs as overlay succeeds
+			echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is true"
+			mount_overlay_system
 		else
-			echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay image"
-			boot_wz_mini
+			echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is false"
 		fi
-	fi	
+	else
+		echo "Mounting rootfs as overlay failed, falling back to wz_mini without overlay image"
+		mount_wz_mini
+	fi
 else
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is false"
-	boot_wz_mini
+	mount_wz_mini
 fi
+
+##### BOOTING #####
+boot_wz_mini

--- a/init
+++ b/init
@@ -1,17 +1,24 @@
 #!/bin/sh
+## wz_mini initramfs init
 
 exec 1> /tmp/wz_mini_initramfs.log 2>&1
 
 set -x
 
-echo "welcome to wz_mini initramfs"
+echo "Welcome to wz_mini initramfs"
+WZMINI_CONFIG_FILE=/sdcard/wz_mini/wz_mini.conf
+WZMINI_INIT_FILE=/sdcard/wz_mini/etc/init.d/wz_init.sh
+WZMINI_INIT_FILE_NEWROOT=/opt/wz_mini/etc/init.d/wz_init.sh
+WZMINI_OVERLAY_FILE=/sdcard/wz_mini-overlay.img
+WZMINI_KERNEL_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
+
 
 # devtmpfs does not get automounted for initramfs
 mount -t devtmpfs devtmpfs /dev
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 
-#Required delay on T20/T31
+# Required delay on T20/T31
 sleep 1
 
 echo "Check for T20 platform"
@@ -20,11 +27,11 @@ if [ -b /dev/mtdblock10 ]; then
 
 	echo "Found T20"
 
-	#T20: Need to export the sd card enable gpio manually
+	# T20: Need to export the sd card enable gpio manually
 	echo 43 > /sys/class/gpio/export
 	echo in > /sys/class/gpio/gpio43/direction
 
-	#T20: Insert required delay for sd card init
+	# T20: Insert required delay for sd card init
 	sleep 3
 
 else
@@ -44,17 +51,10 @@ if ! [ -d /sys/class/gpio/gpio39 ]; then
 fi
 
 mkdir -p /sdcard
+mkdir /stock_rootfs
+mkdir /newroot
+mount -t squashfs /dev/mtdblock2 /stock_rootfs
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
-
-if [ -f /sdcard/wz_mini/wz_mini.conf ]; then
-        source /sdcard/wz_mini/wz_mini.conf
-fi
-
-
-initram_init() {
-
-mkdir /wz
-mount -t squashfs /dev/mtdblock2 /wz
 
 if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 	/led.sh &
@@ -70,54 +70,86 @@ if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 	echo 0 > /sys/class/gpio/gpio38/value
 fi
 
-if [ ! -f /sdcard/wz_mini/etc/init.d/wz_init.sh ]; then
-
-	echo "wz_mini not found, booting stock"
-
-	mount --move /dev /wz/dev
-	mount --move /sys /wz/sys
-	mount --move /proc /wz/proc
-
-	cp /tmp/wz_mini_initramfs.log /sdcard/wz_mini_initramfs.log
-
-	umount /sdcard
-
-	exec busybox switch_root /wz /linuxrc
-
-else
-
-	echo "Loading wz_mini..."
-
-	mkdir -p /wz/dev
-	mkdir -p /wz/sys
-
-
-	mount --move /dev /wz/dev
-	mount --move /sys /wz/sys
-	mount --move /proc /wz/proc
-
-	#mkdir -p /wz/media/mmc
-	mount --move /sdcard /wz/opt
-
-	cp /tmp/wz_mini_initramfs.log /wz/opt/wz_mini_initramfs.log
-
-	#exec busybox switch_root /wz /linuxrc
-	exec busybox switch_root /wz /opt/wz_mini/etc/init.d/wz_init.sh
-
-fi
-
+move_virtual_filesystems() { # Move virtual file systems to new root
+	echo "Moving /dev,/sys,/proc to /newroot"
+	mount --move /dev /newroot/dev
+	mount --move /sys /newroot/sys
+	mount --move /proc /newroot/proc
 }
 
-if [ -f /sdcard/wz_mini/wz_mini.conf ]; then
+boot_stock() {
+	mount --move /stock_rootfs /newroot
+	move_virtual_filesystems
+	echo "Switching to /newroot with stock init"
+	exec busybox switch_root /newroot /linuxrc
+}
 
-	source /sdcard/wz_mini/wz_mini.conf
-
-	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
-		exec /bin/sh
-	else
-		echo "initramfs debug disabled"
-		initram_init
-	fi
+boot_wz_mini() {
+if ! [ -f $WZMINI_INIT_FILE ]; then
+	echo "Booting with stock firmware because $WZMINI_INIT_FILE is missing"
+	boot_stock
 else
-		initram_init
+	mount --move /stock_rootfs /newroot
+	mount --move /sdcard /newroot/opt
+	move_virtual_filesystems
+	echo "Switching to /newroot with wz_mini init"
+	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
+	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
+fi
+}
+
+boot_wz_mini_overlay() {
+if ! grep -q "overlayfs" /proc/filesystems; then
+	boot_stock
+else
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/jbd2/jbd2.ko
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/mbcache.ko
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/ext4/ext4.ko
+
+	mkdir /wz_mini-overlay
+	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /wz_mini-overlay
+
+	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/wz_mini-overlay /newroot
+
+	mkdir -p /newroot/stock_rootfs
+	mkdir -p /newroot/wz_mini-overlay
+
+	move_virtual_filesystems
+	mount --move /sdcard /newroot/opt
+	mount --move /stock_rootfs /newroot/stock_rootfs
+	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
+	
+	echo "Switching to /newroot with wz_mini init and overlayfs"
+	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
+	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
+fi
+}
+
+
+# Boot with stock init if wz_mini.conf is missing
+if ! [ -f $WZMINI_CONFIG_FILE ]; then
+	echo "$WZMINI_CONFIG_FILE is missing, falling back to stock init"
+	boot_stock
+else
+	echo "$WZMINI_CONFIG_FILE is found"
+	source $WZMINI_CONFIG_FILE
+	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
+		echo "Starting initramfs debug mode"
+		exec /bin/sh
+	fi
+fi
+
+# Boot with overlay image if the option is used
+if [[ "$ENABLE_OVERLAY" == "true" ]]; then
+	echo "ENABLE_OVERLAY option is true"
+	if [ -f $WZMINI_OVERLAY_FILE ]; then
+		echo "$WZMINI_OVERLAY_FILE is found"
+		boot_wz_mini_overlay
+	else
+		echo "$WZMINI_OVERLAY_FILE is missing, fallling back to wz_mini without overlayfs"
+		boot_wz_mini
+	fi	
+else
+	echo "ENABLE_OVERLAY option is false"
+	boot_wz_mini
 fi

--- a/init
+++ b/init
@@ -56,7 +56,9 @@ mkdir /newroot
 mount -t squashfs /dev/mtdblock2 /stock_rootfs
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
 
+fsck_sdcard() {
 if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+	echo "Running fsck on SD Card"
 	/led.sh &
 	led_pid="$!"
 	cp /sdcard/wz_mini/bin/fsck.vfat /tmp/fsck.vfat
@@ -69,6 +71,7 @@ if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 	echo 1 > /sys/class/gpio/gpio39/value
 	echo 0 > /sys/class/gpio/gpio38/value
 fi
+}
 
 move_virtual_filesystems() { # Move virtual file systems to new root
 	echo "Moving /dev,/sys,/proc to /newroot"
@@ -133,6 +136,7 @@ if ! [ -f $WZMINI_CONFIG_FILE ]; then
 else
 	echo "$WZMINI_CONFIG_FILE is found"
 	source $WZMINI_CONFIG_FILE
+	fsck_sdcard
 	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
 		echo "Starting initramfs debug mode"
 		exec /bin/sh

--- a/init
+++ b/init
@@ -142,7 +142,7 @@ else
 	move_virtual_filesystems
 
 	echo "Switching to /newroot with wz_mini init and overlayfs"
-	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
+	cp /tmp/wz_mini_initramfs.log /newroot/sdcard/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
 fi
 }

--- a/init
+++ b/init
@@ -116,9 +116,15 @@ else
 
 	mkdir -p /newroot/stock_rootfs
 	mkdir -p /newroot/wz_mini-overlay
+	mkdir -p /newroot/sdcard
+	mkdir -p /newroot/opt/wz_mini
+	mkdir -p /opt/wz_mini
 
 	move_virtual_filesystems
-	mount --move /sdcard /newroot/opt
+	mount --bind /sdcard/wz_mini /opt/wz_mini
+	mount --move /opt/wz_mini /newroot/opt/wz_mini
+	mount --move /sdcard /newroot/sdcard
+
 	mount --move /stock_rootfs /newroot/stock_rootfs
 	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
 	

--- a/init
+++ b/init
@@ -135,7 +135,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	echo "Mounting rootfs as overlay"
 	mount -t overlayfs overlayfs -o lowerdir=/rom,upperdir=/overlay /newroot
 
-	mounting "SD Card to /sdcard and wz_mini directory to /opt/wz_mini"  This lets /opt have file permissions support
+	echo "Mounting SD Card to /sdcard and wz_mini directory to /opt/wz_mini"  This lets /opt have file permissions support
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini

--- a/init
+++ b/init
@@ -110,13 +110,13 @@ else
 	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
 	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
-	mkdir /wz_mini-overlay
-	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /wz_mini-overlay
+	mkdir /overlay
+	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay
 
-	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/wz_mini-overlay /newroot
+	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/overlay /newroot
 
-	mkdir -p /newroot/wz_mini-overlay_mnt # Put all required mountpoint directories here to tidy up /
-	mkdir -p /newroot/wz_mini-overlay
+	mkdir -p /newroot/overlay_mnt # Put all required mountpoint directories here to tidy up /
+	mkdir -p /newroot/overlay
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini
@@ -125,18 +125,18 @@ else
 	mount --move /opt/wz_mini /newroot/opt/wz_mini
 	mount --move /sdcard /newroot/sdcard
 
-	mkdir -p /newroot/wz_mini-overlay_mnt
-	mkdir -p /newroot/wz_mini-overlay_mnt/stock_rootfs
-	mount --move /stock_rootfs /newroot/wz_mini-overlay_mnt/stock_rootfs
-	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
+	mkdir -p /newroot/overlay_mnt
+	mkdir -p /newroot/overlay_mnt/stock_rootfs
+	mount --move /stock_rootfs /newroot/overlay_mnt/stock_rootfs
+	mount --move /overlay /newroot/overlay
 
 	if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then
 		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION is true"
 		echo "Mounting /system as overlay"
-		mkdir -p /newroot/wz_mini-overlay_mnt/stock_system
-		mkdir -p /newroot/wz_mini-overlay_mnt/system_overlay
-		mount -t squashfs /dev/mtdblock3 /newroot/wz_mini-overlay_mnt/stock_system
-		mount -t overlayfs overlayfs -o lowerdir=/newroot/wz_mini-overlay_mnt/stock_system,upperdir=/newroot/wz_mini-overlay_mnt/system_overlay /newroot/system
+		mkdir -p /newroot/overlay_mnt/stock_system
+		mkdir -p /newroot/overlay_mnt/system_overlay
+		mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
+		mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay /newroot/system
 	fi
 
 	move_virtual_filesystems

--- a/init
+++ b/init
@@ -126,7 +126,7 @@ else
 	mount --move /stock_rootfs /newroot/stock_rootfs
 	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
 	
-	if [[ "$MOUNT_SYSTEM_PARTITION_AS_OVERLAY" == "true" ]]; then
+	if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then
 		mkdir -p /newroot/stock_system
 		mkdir -p /newroot/wz_mini-overlay/system_overlay
 		mount -t squashfs /dev/mtdblock3 /newroot/stock_system

--- a/init
+++ b/init
@@ -82,6 +82,7 @@ boot_stock() {
 	mount --move /stock_rootfs /newroot
 	move_virtual_filesystems
 	echo "Switching to /newroot with stock init"
+	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
 	exec busybox switch_root /newroot /linuxrc
 }
 
@@ -117,14 +118,20 @@ else
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini
-
-	move_virtual_filesystems
+	
 	mount --bind /sdcard/wz_mini /opt/wz_mini
 	mount --move /opt/wz_mini /newroot/opt/wz_mini
 	mount --move /sdcard /newroot/sdcard
 
 	mount --move /stock_rootfs /newroot/stock_rootfs
 	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
+
+	mkdir -p /newroot/stock_system
+	mkdir -p /newroot/wz_mini-overlay/system_overlay
+	mount -t squashfs /dev/mtdblock3 /newroot/stock_system
+	mount -t overlayfs overlayfs -o lowerdir=/newroot/stock_system,upperdir=/newroot/wz_mini-overlay/system_overlay /newroot/system
+
+	move_virtual_filesystems
 	
 	echo "Switching to /newroot with wz_mini init and overlayfs"
 	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log

--- a/init
+++ b/init
@@ -116,7 +116,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	if ! [ -f $WZMINI_OVERLAY_FILE ]; then
 		echo "$WZMINI_OVERLAY_FILE is missing"
 		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
-			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" # Create overlay image from compressed empty overlay image file
+			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE to create overlay image"
 			/tmp/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
 		else
 			{ echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing" ; return 1 ; }
@@ -135,7 +135,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	echo "Mounting rootfs as overlay"
 	mount -t overlayfs overlayfs -o lowerdir=/rom,upperdir=/overlay /newroot
 
-	echo "Mounting SD Card to /sdcard and wz_mini directory to /opt/wz_mini"  This lets /opt have file permissions support
+	echo "Mounting SD Card to /sdcard and wz_mini directory to /opt/wz_mini, this lets /opt have file permissions support"
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini

--- a/init
+++ b/init
@@ -53,7 +53,7 @@ if ! [ -d /sys/class/gpio/gpio39 ]; then
 fi
 
 mkdir /sdcard
-mkdir /sdcard2
+mkdir /sdcard2 # Create this temporary directory to store log file on SD card regardless of where it is mounted before switching root
 mkdir /rom
 mkdir /newroot
 mount -t squashfs /dev/mtdblock2 /rom

--- a/init
+++ b/init
@@ -12,6 +12,7 @@ WZMINI_INIT_FILE_NEWROOT=/opt/wz_mini/etc/init.d/wz_init.sh
 WZMINI_OVERLAY_FILE=/sdcard/wz_mini-overlay.img
 WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE=/sdcard/wz_mini/overlay_empty.img.gz
 WZMINI_KERNEL_MODULE_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
+STOCK_INITD_RCS=/newroot/etc/init.d/rcS
 
 
 # devtmpfs does not get automounted for initramfs
@@ -58,6 +59,7 @@ mkdir /newroot
 mount -t squashfs /dev/mtdblock2 /stock_rootfs
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
 mount -t vfat /dev/mmcblk0p1 /sdcard2 -o rw,umask=0000,dmask=0000
+cp /sdcard/wz_mini/bin/busybox /tmp/busybox
 
 fsck_sdcard() {
 	echo "Running fsck on SD Card"
@@ -114,7 +116,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 		# Create overlay image from compressed empty overlay image file
 		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
 		echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
-			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
+			/tmp/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
 		else
 			{ echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing" ; return 1 ; }
 		fi
@@ -146,14 +148,21 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	mount --move /overlay /newroot/overlay
 }
 
-mount_overlay_system() { # Mount /system as overlay
+mount_overlay_driver() { # Mount /system as overlay
 	echo "Mounting /system as overlay"
 	mkdir -p /newroot/overlay_mnt/stock_system
-	mkdir -p /newroot/overlay_mnt/system_overlay
+	mkdir -p /newroot/overlay_mnt/system_overlay-upper
 	mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
-	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay /newroot/system
+	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay-upper /newroot/system
 }
 
+mount_overlay_configs() { # Mount /configs as overlay
+	echo "Mounting /configs as overlay"
+	mkdir -p /newroot/overlay_mnt/stock_configs
+	mkdir -p /newroot/overlay_mnt/configs_overlay-upper
+	mount -t jffs2 /dev/mtdblock6 /newroot/overlay_mnt/stock_configs
+	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_configs,upperdir=/newroot/overlay_mnt/configs_overlay-upper /newroot/configs
+}
 
 
 ##### ERROR CHECKING AND DEBUGGING #####
@@ -179,6 +188,7 @@ fi
 if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
 	echo "DEBUG_INITRAMFS_ENABLED value is true"
 	echo "Starting initramfs debug mode"
+	exec &>/dev/ttyS1
 	exec /bin/sh
 else
 	echo "DEBUG_INITRAMFS_ENABLED value is false"
@@ -189,11 +199,19 @@ fi
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
 	if mount_overlay_rootfs; then
-		if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then # Mount /system as overlay if only mounting rootfs as overlay succeeds
-			echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is true"
-			mount_overlay_system
+		if [[ "$ENABLE_OVERLAY_FOR_DRIVER_PARTITON" == "true" ]]; then # Mount /system as overlay if only mounting rootfs as overlay succeeds
+			echo "ENABLE_OVERLAY_FOR_DRIVER_PARTITON value is true"
+			mount_overlay_driver
 		else
-			echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is false"
+			echo "ENABLE_OVERLAY_FOR_DRIVER_PARTITON value is false"
+		fi
+		if [[ "$ENABLE_OVERLAY_FOR_CONFIGS_PARTITION" == "true" ]]; then # Mount /configs as overlay if only mounting rootfs as overlay succeeds
+			echo "ENABLE_OVERLAY_FOR_CONFIGS_PARTITION value is true"
+			/tmp/busybox sed -i 's~mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~#mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~g' $STOCK_INITD_RCS
+			mount_overlay_configs
+		else
+			echo "ENABLE_OVERLAY_FOR_CONFIGS_PARTITION value is false"
+			/tmp/busybox sed -i 's~#mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~g' $STOCK_INITD_RCS
 		fi
 	else
 		echo "Mounting rootfs as overlay failed, falling back to wz_mini without overlay image"

--- a/init
+++ b/init
@@ -177,6 +177,6 @@ if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 		boot_wz_mini
 	fi	
 else
-	echo "ENABLE_OVERLAY_ROR_ROOTFS option is false"
+	echo "ENABLE_OVERLAY_FOR_ROOTFS option is false"
 	boot_wz_mini
 fi

--- a/init
+++ b/init
@@ -115,7 +115,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 
 	if ! [ -f $WZMINI_OVERLAY_FILE ]; then
 		echo "$WZMINI_OVERLAY_FILE is missing"
-		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
+		if [ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]; then
 			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE to create overlay image"
 			/tmp/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
 		else

--- a/init
+++ b/init
@@ -183,7 +183,6 @@ else
 fi
 
 
-
 ##### MOUNTING #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
@@ -202,6 +201,7 @@ else
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is false"
 	mount_wz_mini
 fi
+
 
 ##### BOOTING #####
 boot_wz_mini

--- a/init
+++ b/init
@@ -112,7 +112,7 @@ else
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
 	mkdir /overlay
-	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE, falling back to wz_mini without overlay" ; boot_wz_mini ; }
+	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE, falling back to wz_mini without overlay image" ; boot_wz_mini ; }
 
 	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/overlay /newroot
 
@@ -186,10 +186,10 @@ if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 		# Create overlay image from compressed empty overlay image 
 		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
 			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
-			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to extract $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE, falling back to wz_mini without overlay" ; boot_wz_mini ; }
+			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to extract $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE, falling back to wz_mini without overlay image" ; boot_wz_mini ; }
 			boot_wz_mini_overlay
 		else
-			echo "$WZMINI_OVERLAY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay"
+			echo "$WZMINI_OVERLAY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay image"
 			boot_wz_mini
 		fi
 	fi	

--- a/init
+++ b/init
@@ -14,19 +14,20 @@ WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE=/sdcard/wz_mini/overlay_empty.img.gz
 WZMINI_KERNEL_MODULE_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
 
 
-
+##### MOUNTING VIRTUAL FILE SYSTEMS  #####
 # devtmpfs does not get automounted for initramfs
 mount -t devtmpfs devtmpfs /dev
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 
+
+##### INITIALIZING GPIO #####
 # Required delay on T20/T31
 sleep 1
 
 echo "Check for T20 platform"
 
 if [ -b /dev/mtdblock10 ]; then
-
 	echo "Found T20"
 
 	# T20: Need to export the sd card enable gpio manually
@@ -35,7 +36,6 @@ if [ -b /dev/mtdblock10 ]; then
 
 	# T20: Insert required delay for sd card init
 	sleep 3
-
 else
 	echo "Not T20"
 fi
@@ -52,6 +52,8 @@ if ! [ -d /sys/class/gpio/gpio39 ]; then
 	echo 1 > /sys/class/gpio/gpio39/value
 fi
 
+
+##### MOUNTING SD CARD AND STOCK ROOTFS #####
 mkdir /sdcard
 mkdir /sdcard2 # Create this temporary directory to store log file on SD card regardless of where it is mounted before switching root
 mkdir /rom
@@ -60,6 +62,7 @@ mount -t squashfs /dev/mtdblock2 /rom
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
 mount -t vfat /dev/mmcblk0p1 /sdcard2 -o rw,umask=0000,dmask=0000
 cp /sdcard/wz_mini/bin/busybox /tmp/busybox
+
 
 fsck_sdcard() {
 	echo "Running fsck on SD Card"
@@ -179,7 +182,7 @@ if ! [ -f $WZMINI_INIT_FILE ]; then
 fi
 
 
-##### MOUNTING #####
+##### MOUNTING NEWROOT #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
 	mount_overlay_rootfs || { echo "Failed to mount rootfs as overlay, falling back to wz_mini mounting" ; mount_wz_mini ; }

--- a/init
+++ b/init
@@ -12,7 +12,7 @@ WZMINI_INIT_FILE_NEWROOT=/opt/wz_mini/etc/init.d/wz_init.sh
 WZMINI_OVERLAY_FILE=/sdcard/wz_mini-overlay.img
 WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE=/sdcard/wz_mini/overlay_empty.img.gz
 WZMINI_KERNEL_MODULE_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
-STOCK_INITD_RCS=/newroot/etc/init.d/rcS
+
 
 
 # devtmpfs does not get automounted for initramfs
@@ -54,9 +54,9 @@ fi
 
 mkdir /sdcard
 mkdir /sdcard2
-mkdir /stock_rootfs
+mkdir /rom
 mkdir /newroot
-mount -t squashfs /dev/mtdblock2 /stock_rootfs
+mount -t squashfs /dev/mtdblock2 /rom
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
 mount -t vfat /dev/mmcblk0p1 /sdcard2 -o rw,umask=0000,dmask=0000
 cp /sdcard/wz_mini/bin/busybox /tmp/busybox
@@ -84,7 +84,7 @@ move_virtual_filesystems() { # Move virtual file systems to new root
 }
 
 boot_stock() {
-	mount --move /stock_rootfs /newroot
+	mount --move /rom /newroot
 	move_virtual_filesystems
 	echo "Switching root to /newroot with stock init"
 	cp /tmp/wz_mini_initramfs.log /sdcard2/wz_mini_initramfs.log
@@ -101,7 +101,7 @@ boot_wz_mini() {
 }
 
 mount_wz_mini() {
-	mount --move /stock_rootfs /newroot
+	mount --move /rom /newroot
 	mount --move /sdcard /newroot/opt
 }
 
@@ -130,10 +130,8 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	mkdir /overlay
 	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE" ; return 1 ; }
 
-	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/overlay /newroot
+	mount -t overlayfs overlayfs -o lowerdir=/rom,upperdir=/overlay /newroot
 
-	mkdir -p /newroot/overlay_mnt # Put all required mountpoint directories here to tidy up /
-	mkdir -p /newroot/overlay
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini
@@ -142,27 +140,12 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	mount --move /opt/wz_mini /newroot/opt/wz_mini
 	mount --move /sdcard /newroot/sdcard
 
-	mkdir -p /newroot/overlay_mnt
-	mkdir -p /newroot/overlay_mnt/stock_rootfs
-	mount --move /stock_rootfs /newroot/overlay_mnt/stock_rootfs
+	mkdir -p /newroot/rom
+	mkdir -p /newroot/overlay
+	mount --move /rom /newroot/rom
 	mount --move /overlay /newroot/overlay
 }
 
-mount_overlay_driver() { # Mount /system as overlay
-	echo "Mounting /system as overlay"
-	mkdir -p /newroot/overlay_mnt/stock_system
-	mkdir -p /newroot/overlay_mnt/system_overlay-upper
-	mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
-	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay-upper /newroot/system
-}
-
-mount_overlay_configs() { # Mount /configs as overlay
-	echo "Mounting /configs as overlay"
-	mkdir -p /newroot/overlay_mnt/stock_configs
-	mkdir -p /newroot/overlay_mnt/configs_overlay-upper
-	mount -t jffs2 /dev/mtdblock6 /newroot/overlay_mnt/stock_configs
-	mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_configs,upperdir=/newroot/overlay_mnt/configs_overlay-upper /newroot/configs
-}
 
 
 ##### ERROR CHECKING AND DEBUGGING #####
@@ -176,6 +159,7 @@ if ! [ -f $WZMINI_INIT_FILE ]; then
 	boot_stock
 fi
 
+/tmp/busybox dos2unix $WZMINI_CONFIG_FILE
 source $WZMINI_CONFIG_FILE
 
 if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
@@ -196,29 +180,11 @@ fi
 
 
 ##### MOUNTING #####
-if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
-	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
-	if mount_overlay_rootfs; then
-		if [[ "$ENABLE_OVERLAY_FOR_DRIVER_PARTITON" == "true" ]]; then # Mount /system as overlay if only mounting rootfs as overlay succeeds
-			echo "ENABLE_OVERLAY_FOR_DRIVER_PARTITON value is true"
-			mount_overlay_driver
-		else
-			echo "ENABLE_OVERLAY_FOR_DRIVER_PARTITON value is false"
-		fi
-		if [[ "$ENABLE_OVERLAY_FOR_CONFIGS_PARTITION" == "true" ]]; then # Mount /configs as overlay if only mounting rootfs as overlay succeeds
-			echo "ENABLE_OVERLAY_FOR_CONFIGS_PARTITION value is true"
-			/tmp/busybox sed -i 's~mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~#mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~g' $STOCK_INITD_RCS
-			mount_overlay_configs
-		else
-			echo "ENABLE_OVERLAY_FOR_CONFIGS_PARTITION value is false"
-			/tmp/busybox sed -i 's~#mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~mount\ -t\ jffs2\ /dev/mtdblock6\ /configs~g' $STOCK_INITD_RCS
-		fi
-	else
-		echo "Mounting rootfs as overlay failed, falling back to wz_mini without overlay image"
-		mount_wz_mini
-	fi
+if [[ "$ENABLE_OVERLAY_IMAGE" == "true" ]]; then
+	echo "ENABLE_OVERLAY_IMAGE value is true"
+	mount_overlay_rootfs
 else
-	echo "ENABLE_OVERLAY_FOR_ROOTFS value is false"
+	echo "ENABLE_OVERLAY_IMAGE value is false"
 	mount_wz_mini
 fi
 

--- a/init
+++ b/init
@@ -10,7 +10,7 @@ WZMINI_CONFIG_FILE=/sdcard/wz_mini/wz_mini.conf
 WZMINI_INIT_FILE=/sdcard/wz_mini/etc/init.d/wz_init.sh
 WZMINI_INIT_FILE_NEWROOT=/opt/wz_mini/etc/init.d/wz_init.sh
 WZMINI_OVERLAY_FILE=/sdcard/wz_mini-overlay.img
-WZMINI_KERNEL_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
+WZMINI_KERNEL_MODULE_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
 
 
 # devtmpfs does not get automounted for initramfs
@@ -50,7 +50,7 @@ if ! [ -d /sys/class/gpio/gpio39 ]; then
 	echo 1 > /sys/class/gpio/gpio39/value
 fi
 
-mkdir -p /sdcard
+mkdir /sdcard
 mkdir /stock_rootfs
 mkdir /newroot
 mount -t squashfs /dev/mtdblock2 /stock_rootfs
@@ -72,7 +72,7 @@ fsck_sdcard() {
 }
 
 move_virtual_filesystems() { # Move virtual file systems to new root
-	echo "Moving /dev,/sys,/proc to /newroot"
+	echo "Moving /dev, /sys, /proc to /newroot"
 	mount --move /dev /newroot/dev
 	mount --move /sys /newroot/sys
 	mount --move /proc /newroot/proc
@@ -88,7 +88,7 @@ boot_stock() {
 
 boot_wz_mini() {
 if ! [ -f $WZMINI_INIT_FILE ]; then
-	echo "Booting with stock firmware because $WZMINI_INIT_FILE is missing"
+	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
 	boot_stock
 else
 	mount --move /stock_rootfs /newroot
@@ -102,39 +102,45 @@ fi
 
 boot_wz_mini_overlay() {
 if ! grep -q "overlayfs" /proc/filesystems; then
-	boot_stock
+	echo "overlayfs supprort is missing from this kernel, falling back to wz_mini firmware"
+	boot_wz_mini
 else
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/jbd2/jbd2.ko
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/mbcache.ko
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_PATH/kernel/fs/ext4/ext4.ko
+	echo "Mounting rootfs as overlay"
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/jbd2/jbd2.ko
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
+	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
 	mkdir /wz_mini-overlay
 	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /wz_mini-overlay
 
 	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/wz_mini-overlay /newroot
 
-	mkdir -p /newroot/stock_rootfs
+	mkdir -p /newroot/wz_mini-overlay_mnt # Put all required mountpoint directories here to tidy up /
 	mkdir -p /newroot/wz_mini-overlay
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini
-	
-	mount --bind /sdcard/wz_mini /opt/wz_mini
+
+	mount --bind /sdcard/wz_mini /opt/wz_mini # Mount (sdcard) to /sdcard and (sdcard)/wz_mini to /opt/wz_mini to let /opt have file permissions support
 	mount --move /opt/wz_mini /newroot/opt/wz_mini
 	mount --move /sdcard /newroot/sdcard
 
-	mount --move /stock_rootfs /newroot/stock_rootfs
+	mkdir -p /newroot/wz_mini-overlay_mnt
+	mkdir -p /newroot/wz_mini-overlay_mnt/stock_rootfs
+	mount --move /stock_rootfs /newroot/wz_mini-overlay_mnt/stock_rootfs
 	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
-	
+
 	if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then
-		mkdir -p /newroot/stock_system
-		mkdir -p /newroot/wz_mini-overlay/system_overlay
-		mount -t squashfs /dev/mtdblock3 /newroot/stock_system
-		mount -t overlayfs overlayfs -o lowerdir=/newroot/stock_system,upperdir=/newroot/wz_mini-overlay/system_overlay /newroot/system
+		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION is true"
+		echo "Mounting /system as overlay"
+		mkdir -p /newroot/wz_mini-overlay_mnt/stock_system
+		mkdir -p /newroot/wz_mini-overlay_mnt/system_overlay
+		mount -t squashfs /dev/mtdblock3 /newroot/wz_mini-overlay_mnt/stock_system
+		mount -t overlayfs overlayfs -o lowerdir=/newroot/wz_mini-overlay_mnt/stock_system,upperdir=/newroot/wz_mini-overlay_mnt/system_overlay /newroot/system
 	fi
-	
+
 	move_virtual_filesystems
-	
+
 	echo "Switching to /newroot with wz_mini init and overlayfs"
 	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
@@ -142,18 +148,18 @@ fi
 }
 
 
-# Boot with stock init if wz_mini.conf is missing
+# Boot with stock firmware if wz_mini.conf is missing
 if ! [ -f $WZMINI_CONFIG_FILE ]; then
-	echo "$WZMINI_CONFIG_FILE is missing, falling back to stock init"
+	echo "$WZMINI_CONFIG_FILE is missing, falling back to stock firmware"
 	boot_stock
 else
 	echo "$WZMINI_CONFIG_FILE is found"
 	source $WZMINI_CONFIG_FILE
-	
+
 	if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 		fsck_sdcard
 	fi
-	
+
 	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
 		echo "Starting initramfs debug mode"
 		exec /bin/sh
@@ -161,8 +167,8 @@ else
 fi
 
 # Boot with overlay image if the option is used
-if [[ "$ENABLE_OVERLAY" == "true" ]]; then
-	echo "ENABLE_OVERLAY option is true"
+if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
+	echo "ENABLE_OVERLAY_FOR_ROOTFS option is true"
 	if [ -f $WZMINI_OVERLAY_FILE ]; then
 		echo "$WZMINI_OVERLAY_FILE is found"
 		boot_wz_mini_overlay
@@ -171,6 +177,6 @@ if [[ "$ENABLE_OVERLAY" == "true" ]]; then
 		boot_wz_mini
 	fi	
 else
-	echo "ENABLE_OVERLAY option is false"
+	echo "ENABLE_OVERLAY_ROR_ROOTFS option is false"
 	boot_wz_mini
 fi

--- a/init
+++ b/init
@@ -178,6 +178,7 @@ if ! [ -f $WZMINI_INIT_FILE ]; then
 	boot_stock
 fi
 
+
 ##### MOUNTING #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"

--- a/init
+++ b/init
@@ -114,7 +114,7 @@ mount_overlay_rootfs() { # Mount rootfs as overlay
 	fi
 
 	if ! [ -f $WZMINI_OVERLAY_FILE ]; then
-		echo "$WZMINI_OVERLAY_FILE is missing"
+		echo "$WZMINI_OVERLAY_FILE is missing"	
 		if [ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]; then
 			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE to create overlay image"
 			/tmp/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
@@ -160,7 +160,7 @@ fi
 /tmp/busybox dos2unix $WZMINI_CONFIG_FILE
 source $WZMINI_CONFIG_FILE
 
-if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
+if [ "$DEBUG_INITRAMFS_ENABLED" == "true" ]; then
 	echo "DEBUG_INITRAMFS_ENABLED value is true"
 	echo "Starting initramfs debug mode"
 	exec &>/dev/ttyS1
@@ -169,7 +169,7 @@ else
 	echo "DEBUG_INITRAMFS_ENABLED value is false"
 fi
 
-if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+if [ "$ENABLE_FSCK_ON_BOOT" == "true" ]; then
 	echo "ENABLE_FSCK_ON_BOOT value is true"
 	fsck_sdcard
 else
@@ -183,7 +183,7 @@ fi
 
 
 ##### MOUNTING NEWROOT #####
-if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
+if [ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]; then
 	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
 	mount_overlay_rootfs || { echo "Failed to mount rootfs as overlay, falling back to wz_mini mounting" ; mount_wz_mini ; }
 else

--- a/init
+++ b/init
@@ -52,10 +52,12 @@ if ! [ -d /sys/class/gpio/gpio39 ]; then
 fi
 
 mkdir /sdcard
+mkdir /sdcard2
 mkdir /stock_rootfs
 mkdir /newroot
 mount -t squashfs /dev/mtdblock2 /stock_rootfs
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
+mount -t vfat /dev/mmcblk0p1 /sdcard2 -o rw,umask=0000,dmask=0000
 
 fsck_sdcard() {
 	echo "Running fsck on SD Card"
@@ -83,14 +85,14 @@ boot_stock() {
 	mount --move /stock_rootfs /newroot
 	move_virtual_filesystems
 	echo "Switching root to /newroot with stock init"
-	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
+	cp /tmp/wz_mini_initramfs.log /sdcard2/wz_mini_initramfs.log
 	exec busybox switch_root /newroot /linuxrc
 }
 
 boot_wz_mini() {
 	move_virtual_filesystems
 	echo "Switching root to /newroot with wz_mini init"
-	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
+	cp /tmp/wz_mini_initramfs.log /sdcard2/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
 }
 
@@ -151,33 +153,36 @@ mount_overlay_system() { # Mount /system as overlay
 }
 
 
+
 ##### ERROR CHECKING AND DEBUGGING #####
 if ! [ -f $WZMINI_CONFIG_FILE ]; then
 	echo "$WZMINI_CONFIG_FILE is missing, falling back to stock firmware"
 	boot_stock
-else
-	source $WZMINI_CONFIG_FILE
-
-	if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
-		echo "ENABLE_FSCK_ON_BOOT value is true"
-		fsck_sdcard
-	else
-		echo "ENABLE_FSCK_ON_BOOT value is false"
-	fi
-
-	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
-		echo "DEBUG_INITRAMFS_ENABLED value is true"
-		echo "Starting initramfs debug mode"
-		exec /bin/sh
-	else
-		echo "DEBUG_INITRAMFS_ENABLED value is false"
-	fi
 fi
 
 if ! [ -f $WZMINI_INIT_FILE ]; then
 	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
 	boot_stock
 fi
+
+source $WZMINI_CONFIG_FILE
+
+if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+	echo "ENABLE_FSCK_ON_BOOT value is true"
+	fsck_sdcard
+else
+	echo "ENABLE_FSCK_ON_BOOT value is false"
+fi
+
+if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
+	echo "DEBUG_INITRAMFS_ENABLED value is true"
+	echo "Starting initramfs debug mode"
+	exec /bin/sh
+else
+	echo "DEBUG_INITRAMFS_ENABLED value is false"
+fi
+
+
 
 ##### MOUNTING #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then

--- a/init
+++ b/init
@@ -82,7 +82,7 @@ move_virtual_filesystems() { # Move virtual file systems to new root
 boot_stock() {
 	mount --move /stock_rootfs /newroot
 	move_virtual_filesystems
-	echo "Switching to /newroot with stock init"
+	echo "Switching root to /newroot with stock init"
 	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
 	exec busybox switch_root /newroot /linuxrc
 }
@@ -95,7 +95,7 @@ else
 	mount --move /stock_rootfs /newroot
 	mount --move /sdcard /newroot/opt
 	move_virtual_filesystems
-	echo "Switching to /newroot with wz_mini init"
+	echo "Switching root to /newroot with wz_mini init"
 	cp /tmp/wz_mini_initramfs.log /newroot/opt/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
 fi
@@ -144,7 +144,7 @@ else
 
 	move_virtual_filesystems
 
-	echo "Switching to /newroot with wz_mini init and overlayfs"
+	echo "Switching root to /newroot with wz_mini init on overlay rootfs"
 	cp /tmp/wz_mini_initramfs.log /newroot/sdcard/wz_mini_initramfs.log
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
 fi

--- a/init
+++ b/init
@@ -10,6 +10,7 @@ WZMINI_CONFIG_FILE=/sdcard/wz_mini/wz_mini.conf
 WZMINI_INIT_FILE=/sdcard/wz_mini/etc/init.d/wz_init.sh
 WZMINI_INIT_FILE_NEWROOT=/opt/wz_mini/etc/init.d/wz_init.sh
 WZMINI_OVERLAY_FILE=/sdcard/wz_mini-overlay.img
+WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE=/sdcard/wz_mini/overlay_empty.img.gz
 WZMINI_KERNEL_MODULE_PATH=/sdcard/wz_mini/lib/modules/3.10.14__isvp_swan_1.0__
 
 
@@ -106,12 +107,12 @@ if ! grep -q "overlayfs" /proc/filesystems; then
 	boot_wz_mini
 else
 	echo "Mounting rootfs as overlay"
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/jbd2/jbd2.ko
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
-	/sdcard/wz_mini/bin/busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
+	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/jbd2/jbd2.ko
+	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
+	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
 	mkdir /overlay
-	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay
+	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE, falling back to wz_mini without overlay" ; boot_wz_mini ; }
 
 	mount -t overlayfs overlayfs -o lowerdir=/stock_rootfs,upperdir=/overlay /newroot
 
@@ -131,12 +132,14 @@ else
 	mount --move /overlay /newroot/overlay
 
 	if [[ "$ENABLE_OVERLAY_FOR_SYSTEM_PARTITION" == "true" ]]; then
-		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION is true"
+		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is true"
 		echo "Mounting /system as overlay"
 		mkdir -p /newroot/overlay_mnt/stock_system
 		mkdir -p /newroot/overlay_mnt/system_overlay
 		mount -t squashfs /dev/mtdblock3 /newroot/overlay_mnt/stock_system
 		mount -t overlayfs overlayfs -o lowerdir=/newroot/overlay_mnt/stock_system,upperdir=/newroot/overlay_mnt/system_overlay /newroot/system
+	else
+		echo "ENABLE_OVERLAY_FOR_SYSTEM_PARTITION value is false"
 	fi
 
 	move_virtual_filesystems
@@ -157,26 +160,40 @@ else
 	source $WZMINI_CONFIG_FILE
 
 	if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+		echo "ENABLE_FSCK_ON_BOOT value is true"
 		fsck_sdcard
+	else
+		echo "ENABLE_FSCK_ON_BOOT value is false"
 	fi
 
 	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
+		echo "DEBUG_INITRAMFS_ENABLED value is true"
 		echo "Starting initramfs debug mode"
 		exec /bin/sh
+	else
+		echo "DEBUG_INITRAMFS_ENABLED value is false"
 	fi
 fi
 
 # Boot with overlay image if the option is used
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
-	echo "ENABLE_OVERLAY_FOR_ROOTFS option is true"
+	echo "ENABLE_OVERLAY_FOR_ROOTFS value is true"
 	if [ -f $WZMINI_OVERLAY_FILE ]; then
 		echo "$WZMINI_OVERLAY_FILE is found"
 		boot_wz_mini_overlay
 	else
-		echo "$WZMINI_OVERLAY_FILE is missing, fallling back to wz_mini without overlayfs"
-		boot_wz_mini
+		echo "$WZMINI_OVERLAY_FILE is missing"
+		# Create overlay image from compressed empty overlay image 
+		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
+			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
+			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to extract $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE, falling back to wz_mini without overlay" ; boot_wz_mini ; }
+			boot_wz_mini_overlay
+		else
+			echo "$WZMINI_OVERLAY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay"
+			boot_wz_mini
+		fi
 	fi	
 else
-	echo "ENABLE_OVERLAY_FOR_ROOTFS option is false"
+	echo "ENABLE_OVERLAY_FOR_ROOTFS value is false"
 	boot_wz_mini
 fi

--- a/init
+++ b/init
@@ -103,7 +103,7 @@ fi
 
 boot_wz_mini_overlay() {
 if ! grep -q "overlayfs" /proc/filesystems; then
-	echo "overlayfs support is missing from this kernel, falling back to wz_mini firmware"
+	echo "overlayfs support is missing from this kernel, falling back to wz_mini"
 	boot_wz_mini
 else
 	echo "Mounting rootfs as overlay"
@@ -189,7 +189,7 @@ if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then
 			/sdcard/wz_mini/bin/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to extract $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE, falling back to wz_mini without overlay image" ; boot_wz_mini ; }
 			boot_wz_mini_overlay
 		else
-			echo "$WZMINI_OVERLAY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay image"
+			echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing, falling back to wz_mini without overlay image"
 			boot_wz_mini
 		fi
 	fi	

--- a/init
+++ b/init
@@ -158,7 +158,7 @@ if ! [ -f $WZMINI_CONFIG_FILE ]; then
 fi
 
 /tmp/busybox dos2unix $WZMINI_CONFIG_FILE
-source $WZMINI_CONFIG_FILE
+source $WZMINI_CONFIG_FILE || { echo "$WZMINI_CONFIG_FILE is invalid, falling back to stock firmware" ; boot_stock ; }
 
 if [ "$DEBUG_INITRAMFS_ENABLED" == "true" ]; then
 	echo "DEBUG_INITRAMFS_ENABLED value is true"

--- a/init
+++ b/init
@@ -86,6 +86,7 @@ boot_stock() {
 	move_virtual_filesystems
 	echo "Switching root to /newroot with stock init"
 	cp /tmp/wz_mini_initramfs.log /sdcard2/wz_mini_initramfs.log
+	umount /sdcard2
 	exec busybox switch_root /newroot /linuxrc
 }
 
@@ -93,6 +94,7 @@ boot_wz_mini() {
 	move_virtual_filesystems
 	echo "Switching root to /newroot with wz_mini init"
 	cp /tmp/wz_mini_initramfs.log /sdcard2/wz_mini_initramfs.log
+	umount /sdcard2
 	exec busybox switch_root /newroot $WZMINI_INIT_FILE_NEWROOT
 }
 

--- a/init
+++ b/init
@@ -125,12 +125,14 @@ else
 
 	mount --move /stock_rootfs /newroot/stock_rootfs
 	mount --move /wz_mini-overlay /newroot/wz_mini-overlay
-
-	mkdir -p /newroot/stock_system
-	mkdir -p /newroot/wz_mini-overlay/system_overlay
-	mount -t squashfs /dev/mtdblock3 /newroot/stock_system
-	mount -t overlayfs overlayfs -o lowerdir=/newroot/stock_system,upperdir=/newroot/wz_mini-overlay/system_overlay /newroot/system
-
+	
+	if [[ "$MOUNT_SYSTEM_PARTITION_AS_OVERLAY" == "true" ]]; then
+		mkdir -p /newroot/stock_system
+		mkdir -p /newroot/wz_mini-overlay/system_overlay
+		mount -t squashfs /dev/mtdblock3 /newroot/stock_system
+		mount -t overlayfs overlayfs -o lowerdir=/newroot/stock_system,upperdir=/newroot/wz_mini-overlay/system_overlay /newroot/system
+	fi
+	
 	move_virtual_filesystems
 	
 	echo "Switching to /newroot with wz_mini init and overlayfs"

--- a/init
+++ b/init
@@ -103,7 +103,7 @@ fi
 
 boot_wz_mini_overlay() {
 if ! grep -q "overlayfs" /proc/filesystems; then
-	echo "overlayfs supprort is missing from this kernel, falling back to wz_mini firmware"
+	echo "overlayfs support is missing from this kernel, falling back to wz_mini firmware"
 	boot_wz_mini
 else
 	echo "Mounting rootfs as overlay"

--- a/init
+++ b/init
@@ -110,36 +110,36 @@ mount_wz_mini() {
 
 mount_overlay_rootfs() { # Mount rootfs as overlay
 	if ! grep -q "overlayfs" /proc/filesystems; then
-		echo "overlayfs support is missing from this kernel"
-		return 1
+		{ echo "overlayfs support is missing from this kernel" ; return 1 ; }
 	fi
 
 	if ! [ -f $WZMINI_OVERLAY_FILE ]; then
 		echo "$WZMINI_OVERLAY_FILE is missing"
-		# Create overlay image from compressed empty overlay image file
 		if [[ -f $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE ]]; then
-		echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE"
+			echo "Decompressing $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" # Create overlay image from compressed empty overlay image file
 			/tmp/busybox gzip -d -k -c $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE > $WZMINI_OVERLAY_FILE || { echo "Failed to decompress $WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE" ; return 1 ; }
 		else
 			{ echo "$WZMINI_OVERLAY_EMPTY_COMPRESSED_FILE is missing" ; return 1 ; }
 		fi
 	fi
 
-	echo "Mounting rootfs as overlay"
+	echo "Loading ext4 kernel module before mounting overlay image"
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/jbd2/jbd2.ko
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/mbcache.ko
 	busybox insmod $WZMINI_KERNEL_MODULE_PATH/kernel/fs/ext4/ext4.ko
 
+	echo "Mounting overlay image"
 	mkdir /overlay
 	mount $WZMINI_OVERLAY_FILE -o loop -t ext2 /overlay || { echo "Failed to mount $WZMINI_OVERLAY_FILE" ; return 1 ; }
 
+	echo "Mounting rootfs as overlay"
 	mount -t overlayfs overlayfs -o lowerdir=/rom,upperdir=/overlay /newroot
 
+	mounting "SD Card to /sdcard and wz_mini directory to /opt/wz_mini"  This lets /opt have file permissions support
 	mkdir -p /newroot/sdcard
 	mkdir -p /newroot/opt/wz_mini
 	mkdir -p /opt/wz_mini
-
-	mount --bind /sdcard/wz_mini /opt/wz_mini # Mount (sdcard) to /sdcard and (sdcard)/wz_mini to /opt/wz_mini to let /opt have file permissions support
+	mount --bind /sdcard/wz_mini /opt/wz_mini
 	mount --move /opt/wz_mini /newroot/opt/wz_mini
 	mount --move /sdcard /newroot/sdcard
 

--- a/init
+++ b/init
@@ -57,7 +57,6 @@ mount -t squashfs /dev/mtdblock2 /stock_rootfs
 mount -t vfat /dev/mmcblk0p1 /sdcard -o rw,umask=0000,dmask=0000
 
 fsck_sdcard() {
-if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 	echo "Running fsck on SD Card"
 	/led.sh &
 	led_pid="$!"
@@ -70,7 +69,6 @@ if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
 	kill $led_pid
 	echo 1 > /sys/class/gpio/gpio39/value
 	echo 0 > /sys/class/gpio/gpio38/value
-fi
 }
 
 move_virtual_filesystems() { # Move virtual file systems to new root
@@ -142,7 +140,11 @@ if ! [ -f $WZMINI_CONFIG_FILE ]; then
 else
 	echo "$WZMINI_CONFIG_FILE is found"
 	source $WZMINI_CONFIG_FILE
-	fsck_sdcard
+	
+	if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+		fsck_sdcard
+	fi
+	
 	if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
 		echo "Starting initramfs debug mode"
 		exec /bin/sh

--- a/init
+++ b/init
@@ -154,20 +154,8 @@ if ! [ -f $WZMINI_CONFIG_FILE ]; then
 	boot_stock
 fi
 
-if ! [ -f $WZMINI_INIT_FILE ]; then
-	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
-	boot_stock
-fi
-
 /tmp/busybox dos2unix $WZMINI_CONFIG_FILE
 source $WZMINI_CONFIG_FILE
-
-if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
-	echo "ENABLE_FSCK_ON_BOOT value is true"
-	fsck_sdcard
-else
-	echo "ENABLE_FSCK_ON_BOOT value is false"
-fi
 
 if [[ "$DEBUG_INITRAMFS_ENABLED" == "true" ]]; then
 	echo "DEBUG_INITRAMFS_ENABLED value is true"
@@ -178,6 +166,17 @@ else
 	echo "DEBUG_INITRAMFS_ENABLED value is false"
 fi
 
+if [[ "$ENABLE_FSCK_ON_BOOT" == "true" ]]; then
+	echo "ENABLE_FSCK_ON_BOOT value is true"
+	fsck_sdcard
+else
+	echo "ENABLE_FSCK_ON_BOOT value is false"
+fi
+
+if ! [ -f $WZMINI_INIT_FILE ]; then
+	echo "$WZMINI_INIT_FILE is missing, falling back to stock firmware"
+	boot_stock
+fi
 
 ##### MOUNTING #####
 if [[ "$ENABLE_OVERLAY_FOR_ROOTFS" == "true" ]]; then


### PR DESCRIPTION
DEBUG_INITRAMFS_ENABLED="true" option is currently unusable untill #2 is fixed.

`wz_mini-overlay.img` can be generated from a computer running Linux:
```bash
truncate -s 200M wz_mini-overlay.img
mkfs.ext2 wz_mini-overlay.img
```

The boot image `factory_t31_ZMC6tiIDQN` is built with [kernel.config](https://github.com/gtxaspec/wz_initramfs/files/12751882/kernel.config.txt)(your [kernel.config](https://gist.github.com/gtxaspec/2e9e08bb14b4e29a2fd2bf43ce286b44) with commented `CONFIG_NETFILTER=`) and an [overlayfs patch](https://github.com/adilinden-oss/overlayfs-patches/blob/master/overlayfs.v18-3.10-rc7.patch)

Overlay image support can be enabled by `ENABLE_OVERLAY="true"` in `wz_mini.conf`
